### PR TITLE
Dockerfile: update to ubuntu 16.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-FROM ubuntu:14.04
+FROM ubuntu:16.04
 
 USER root
 


### PR DESCRIPTION
This updates the container to 16.04 LTS and also makes sure that we have
the fix for CVE-2017-7494 in the container.

Signed-off-by: brian avery <brian.avery@intel.com>