### PR TITLE
Dockerfile: from Ubuntu 18.04 base; SPDX header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,10 @@
 # Copyright (C) 2015-2016 Intel Corporation
+# Copyright (C) 2022 Konsulko Group`
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License version 2 as
-# published by the Free Software Foundation.
+# SPDX-License-Identifier: GPL-2.0-only
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License along
-# with this program; if not, write to the Free Software Foundation, Inc.,
-# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 USER root
 


### PR DESCRIPTION
Use ubuntu-18.04 as a base
Replace license text in header with SPDX-License-Identifier

Signed-off-by: Tim Orling <tim.orling@konsulko.com>