### PR TITLE
Samba test fix

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Build the image
       - name: build

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -23,6 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Install packages on the runner
+      - name: install smbclient
+        run: |
+          sudo apt-get update
+          sudo apt-get install smbclient
+
       # Build the image
       - name: build
         run: docker build -t ${REPO} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 #
 
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 USER root
 


### PR DESCRIPTION
Revert the ubuntu-20.04 bump as that introduces smb4 and our samba.sh and smb.conf are not ready for that.

Install smbclient on the runner so it knows how to mount a cifs to allow the tests to continue passing