### PR TITLE
github/workflows: set GHCR variables

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,10 +15,14 @@ on:
 jobs:
   build-test-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     env:
       REPO: crops/samba
       DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      GHCR_USERNAME: ${{ github.actor }}
+      GHCR_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Set the required variables to allow pushing containers to ghcr.io